### PR TITLE
Add keyword argument splat to wikimedia commons methods

### DIFF
--- a/lib/infoboxer.rb
+++ b/lib/infoboxer.rb
@@ -177,7 +177,7 @@ module Infoboxer
 
   WIKIMEDIA_COMMONS.each do |name, domain|
     define_method name do |**options|
-      wiki("https://#{domain}/w/api.php", options)
+      wiki("https://#{domain}/w/api.php", **options)
     end
   end
 


### PR DESCRIPTION
A very minor fix, that created an issue for me running Ruby 3.0.  Please let me know if there's anything I should do to get this patched upstream.  Thank you for your hard work!